### PR TITLE
set the x-saltorn-client header to react-view

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -116,6 +116,7 @@ export async function loadScView(
     headers: {
       "X-CSRF-Token": (window as any)._sc_globalCsrf,
       "X-Requested-With": "XMLHttpRequest",
+      "X-Saltcorn-Client": "react-view",
     },
     params: query,
   });


### PR DESCRIPTION
- sets req.rvr to true in the server
- when we only use xhr, we get a conflict with pjax